### PR TITLE
Use toolchain for tinygo and wasm-opt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BUILD_DIR := _build
 BUILDTOOL := $(BUILD_DIR)/build-tool
 BUILDTOOL_MAIN := cmd/build-tool/main.go
 BUILDTOOL_PACKAGE := \
+		     internal/build-tool/binaryen.go \
 		     internal/build-tool/bison.go \
 		     internal/build-tool/bpf_asm.go \
 		     internal/build-tool/capnproto.go \
@@ -45,6 +46,8 @@ TEMPEST_SANDBOX_LAUNCHER_GEN := \
 TEMPEST_SANDBOX_LAUNCHER_OBJ := c/sandbox-launcher.o
 TINYGO_VERSION := 0.37.0
 TINYGO := $(TOOLCHAIN_DIR)/tinygo-$(TINYGO_VERSION)/bin/tinygo
+BINARYEN_VERSION := 125
+BINARYEN := $(TOOLCHAIN_DIR)/binaryen-version_$(BINARYEN_VERSION)/bin/wasm-opt
 
 ##
 ## Targets
@@ -169,7 +172,7 @@ check: all
 #
 
 .PHONY: toolchain
-toolchain: $(BISON) $(BPF_ASM) $(CAPNP) $(FLEX) $(GO) $(GOCAPNP) $(TINYGO)
+toolchain: $(BINARYEN) $(BISON) $(BPF_ASM) $(CAPNP) $(FLEX) $(GO) $(GOCAPNP) $(TINYGO)
 
 $(BISON): $(BUILDTOOL)
 	@echo Building Bison $(BISON_VERSION)
@@ -205,6 +208,10 @@ $(GOPATH_DIR):
 $(TINYGO): $(BUILDTOOL)
 	@echo Setting up TinyGo $(TINYGO_VERSION)
 	$(BUILDTOOL) bootstrap-tinygo
+
+$(BINARYEN): $(BUILDTOOL)
+	@echo Setting up Binaryen $(BINARYEN_VERSION)
+	$(BUILDTOOL) bootstrap-binaryen
 
 capnp/%/%.capnp.go: $(BUILDTOOL) $(CAPNP) $(GOCAPNP) capnp/%.capnp
 	$(BUILDTOOL) generate-capnp

--- a/cmd/build-tool/main.go
+++ b/cmd/build-tool/main.go
@@ -13,6 +13,7 @@ const DefaultConfigPath = "./config.toml"
 const DefaultDownloadsFilePath = "./internal/build-tool/downloads.toml"
 
 var CLI struct {
+	BootstrapBinaryen  struct{} `cmd:"" help:"Bootstrap Binaryen (wasm-opt)"`
 	BootstrapBison     struct{} `cmd:"" help:"Bootstrap Bison"`
 	BootstrapBpfAsm    struct{} `cmd:"" help:"Bootstrap bpf_asm" name:"bootstrap-bpf_asm"`
 	BootstrapCapnProto struct{} `cmd:"" help:"Bootstrap Cap'n Proto" name:"bootstrap-capnproto"`
@@ -36,6 +37,12 @@ func main() {
 	}
 
 	switch context.Command() {
+	case "bootstrap-binaryen":
+		messages, err := buildtool.BootstrapBinaryen(config)
+		logMessages(CLI.Verbose, messages)
+		if err != nil {
+			log.Fatal(err)
+		}
 	case "bootstrap-bison":
 		messages, err := buildtool.BootstrapBison(config)
 		logMessages(CLI.Verbose, messages)

--- a/internal/build-tool/binaryen.go
+++ b/internal/build-tool/binaryen.go
@@ -150,6 +150,10 @@ func BootstrapBinaryen(buildToolConfig *RuntimeConfigBuildTool) ([]string, error
 	} else {
 		transformBinaryenTarGz := transformBinaryenTarGzFactory(binaryenConfig.toolchainDir, binaryenConfig.versionedDir)
 		err = extractTarGz(downloadPath, filterBinaryenTarGz(binaryenConfig.versionedDir), transformBinaryenTarGz)
+		if err != nil {
+			messages = append(messages, fmt.Sprintf("Failed to extract %s", downloadPath))
+			return messages, err
+		}
 	}
 	binaryenConfig.executable = filepath.Join(binaryenConfig.toolchainDir, "bin", "wasm-opt")
 	// Update the modified time of the Binaryen executable.
@@ -169,7 +173,7 @@ func BootstrapBinaryen(buildToolConfig *RuntimeConfigBuildTool) ([]string, error
 	return messages, err
 }
 
-func filterBinaryenTarGz(versionedDir string) func(string) bool {
+func filterBinaryenTarGz(versionedDir string) fileFilter {
 	prefix := versionedDir + "/"
 	return func(filePath string) bool {
 		acceptable := strings.HasPrefix(filePath, prefix)

--- a/internal/build-tool/binaryen.go
+++ b/internal/build-tool/binaryen.go
@@ -49,7 +49,7 @@ type binaryenDownloadUrlTemplateValues struct {
 // text/template uses these struct fields from a separate package, so they must be in PascalCase.
 type binaryenFilenameTemplateValues struct {
 	Arch    string
-	OS      string
+	Os      string
 	Version string
 }
 
@@ -196,7 +196,7 @@ func getBinaryenConfig(buildToolConfig *RuntimeConfigBuildTool) (*binaryenConfig
 	// Download File
 	filenameValues := binaryenFilenameTemplateValues{
 		Arch:    getBinaryenArch(),
-		OS:      getBinaryenOS(),
+		Os:      getBinaryenOS(),
 		Version: version,
 	}
 	filenameTemplate, err := template.New("filename").Parse(buildToolConfig.Binaryen.filenameTemplate)

--- a/internal/build-tool/binaryen.go
+++ b/internal/build-tool/binaryen.go
@@ -1,5 +1,5 @@
 // Tempest
-// Copyright (c) 2025 Sandstorm Development Team and contributors
+// Copyright (c) 2026 Sandstorm Development Team and contributors
 // All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/build-tool/binaryen.go
+++ b/internal/build-tool/binaryen.go
@@ -1,0 +1,283 @@
+// Tempest
+// Copyright (c) 2025 Sandstorm Development Team and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildtool
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/template"
+)
+
+type binaryenConfig struct {
+	downloadFile        string
+	downloadUrl         string
+	executable          string
+	expectedFileSize    int64
+	expectedSha256      string
+	toolchainDir        string
+	toolchainExecutable string
+	toolchainVersion    string
+	version             string
+	versionedDir        string
+}
+
+// text/template uses these struct fields from a separate package, so they must be in PascalCase.
+type binaryenDownloadUrlTemplateValues struct {
+	Filename string
+	Version  string
+}
+
+// text/template uses these struct fields from a separate package, so they must be in PascalCase.
+type binaryenFilenameTemplateValues struct {
+	Arch    string
+	OS      string
+	Version string
+}
+
+// getBinaryenArch maps Go's GOARCH to binaryen's architecture naming
+func getBinaryenArch() string {
+	switch runtime.GOARCH {
+	case "arm64":
+		if runtime.GOOS == "darwin" {
+			return "arm64"
+		}
+		return "aarch64"
+	case "amd64":
+		return "x86_64"
+	default:
+		return runtime.GOARCH
+	}
+}
+
+// getBinaryenOS maps Go's GOOS to binaryen's OS naming
+func getBinaryenOS() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "macos"
+	default:
+		return runtime.GOOS
+	}
+}
+
+func BootstrapBinaryen(buildToolConfig *RuntimeConfigBuildTool) ([]string, error) {
+	messages := make([]string, 0, 5)
+	binaryenConfig, err := getBinaryenConfig(buildToolConfig)
+	if err != nil {
+		messages = append(messages, "Failed to get Binaryen configuration")
+		return messages, err
+	}
+	if binaryenConfig.executable != "" {
+		executableExists, err := fileExistsAtPath(binaryenConfig.executable)
+		if err != nil {
+			log.Printf("fileExistsAtPath err\n")
+			return messages, err
+		}
+		if executableExists {
+			messages = append(messages, fmt.Sprintf("Skipping download and installation of Binaryen because %s (from config.toml) exists", binaryenConfig.executable))
+			return messages, nil
+		} else {
+			err = fmt.Errorf("User-specified Binaryen executable %s does not exist.", binaryenConfig.executable)
+			return messages, err
+		}
+	}
+	if binaryenConfig.toolchainExecutable != "" {
+		executableExists, err := fileExistsAtPath(binaryenConfig.toolchainExecutable)
+		if err != nil {
+			log.Printf("fileExistsAtPath err\n")
+			return messages, err
+		}
+		if executableExists {
+			if binaryenConfig.version == binaryenConfig.toolchainVersion {
+				messages = append(messages, fmt.Sprintf("Skipping download and installation of Binaryen because %s (toolchain) exists", binaryenConfig.toolchainExecutable))
+				return messages, nil
+			} else {
+				messages = append(messages, fmt.Sprintf("The toolchain executable does not match the desired version.  Continuing."))
+			}
+		}
+	}
+	err = ensureDownloadDirExists(buildToolConfig.Directories.DownloadDir)
+	if err != nil {
+		return messages, err
+	}
+	downloadPath := filepath.Join(buildToolConfig.Directories.DownloadDir, binaryenConfig.downloadFile)
+	downloadPathExists, err := fileExistsAtPath(downloadPath)
+	if err != nil {
+		return messages, err
+	}
+	if downloadPathExists {
+		messages = append(messages, fmt.Sprintf("Skipping Binaryen download because %s exists", downloadPath))
+	} else {
+		err := downloadUrlToDir(binaryenConfig.downloadUrl, buildToolConfig.Directories.DownloadDir, downloadPath)
+		if err != nil {
+			return messages, err
+		}
+	}
+	err = verifyFileSize(binaryenConfig.expectedFileSize, downloadPath)
+	if err != nil {
+		return messages, err
+	}
+	err = verifySha256(binaryenConfig.expectedSha256, downloadPath)
+	if err != nil {
+		return messages, err
+	}
+	messages = append(messages, fmt.Sprintf("%s has the correct SHA-256", downloadPath))
+	executableExists, err := fileExistsAtPath(binaryenConfig.toolchainExecutable)
+	if err != nil {
+		log.Printf("fileExistsAtPath err\n")
+		return messages, err
+	}
+	if executableExists {
+		messages = append(messages, fmt.Sprintf("Refusing to install Binaryen because %s exists", binaryenConfig.toolchainExecutable))
+	} else {
+		transformBinaryenTarGz := transformBinaryenTarGzFactory(binaryenConfig.toolchainDir, binaryenConfig.versionedDir)
+		err = extractTarGz(downloadPath, filterBinaryenTarGz(binaryenConfig.versionedDir), transformBinaryenTarGz)
+	}
+	binaryenConfig.executable = filepath.Join(binaryenConfig.toolchainDir, "bin", "wasm-opt")
+	// Update the modified time of the Binaryen executable.
+	executableExists, err = fileExistsAtPath(binaryenConfig.executable)
+	if err != nil {
+		log.Printf("fileExistsAtPath err\n")
+		return messages, err
+	}
+	if executableExists {
+		err = setFileModifiedTimeToNow(binaryenConfig.executable)
+	}
+	if err != nil {
+		return messages, err
+	}
+	toolchainTomlExecutable := filepath.Join(binaryenConfig.versionedDir, "bin", "wasm-opt")
+	err = updateBinaryenToolchainToml(buildToolConfig.Directories.ToolChainDir, toolchainTomlExecutable, binaryenConfig.version)
+	return messages, err
+}
+
+func filterBinaryenTarGz(versionedDir string) func(string) bool {
+	prefix := versionedDir + "/"
+	return func(filePath string) bool {
+		acceptable := strings.HasPrefix(filePath, prefix)
+		if !acceptable {
+			log.Printf("Rejecting file with invalid prefix: %s\n", filePath)
+		}
+		return acceptable
+	}
+}
+
+func getBinaryenConfig(buildToolConfig *RuntimeConfigBuildTool) (*binaryenConfig, error) {
+	if buildToolConfig.Directories == nil {
+		return nil, fmt.Errorf("buildToolConfig.Directories is nil")
+	}
+	if buildToolConfig.Binaryen == nil {
+		return nil, fmt.Errorf("buildToolConfig.Binaryen is nil")
+	}
+	// Version
+	version := buildToolConfig.Binaryen.version
+	// Download File
+	filenameValues := binaryenFilenameTemplateValues{
+		Arch:    getBinaryenArch(),
+		OS:      getBinaryenOS(),
+		Version: version,
+	}
+	filenameTemplate, err := template.New("filename").Parse(buildToolConfig.Binaryen.filenameTemplate)
+	if err != nil {
+		return nil, err
+	}
+	var filenameBuffer bytes.Buffer
+	err = filenameTemplate.Execute(&filenameBuffer, filenameValues)
+	if err != nil {
+		return nil, err
+	}
+	downloadFile := filenameBuffer.String()
+
+	// Download URL
+	downloadUrlValues := binaryenDownloadUrlTemplateValues{
+		downloadFile,
+		version,
+	}
+	downloadUrlTemplate, err := template.New("downloadUrl").Parse(buildToolConfig.Binaryen.downloadUrlTemplate)
+	if err != nil {
+		return nil, err
+	}
+	var downloadUrlBuffer bytes.Buffer
+	err = downloadUrlTemplate.Execute(&downloadUrlBuffer, downloadUrlValues)
+	if err != nil {
+		return nil, err
+	}
+	downloadUrl := downloadUrlBuffer.String()
+	downloadFileInfo := buildToolConfig.Binaryen.files[downloadFile]
+	if downloadFileInfo == (runtimeConfigFile{}) {
+		return nil, fmt.Errorf("File size and SHA-256 not found in downloads.toml for %s", downloadFile)
+	}
+	// Expected file size and SHA-256
+	expectedFileSize := downloadFileInfo.size
+	expectedSha256 := downloadFileInfo.sha256
+	// Binaryen executable
+	executable := buildToolConfig.Binaryen.Executable
+	// Toolchain directory
+	toolchainDir := buildToolConfig.Binaryen.toolchainDir
+	// Toolchain executable
+	toolchainExecutable := buildToolConfig.Binaryen.ToolChainExecutable
+	// Toolchain version
+	toolchainVersion := buildToolConfig.Binaryen.toolchainVersion
+	// Versioned directory
+	versionedDir := buildToolConfig.Binaryen.versionedDir
+
+	binaryenConfig := new(binaryenConfig)
+	binaryenConfig.downloadFile = downloadFile
+	binaryenConfig.downloadUrl = downloadUrl
+	binaryenConfig.executable = executable
+	binaryenConfig.expectedFileSize = expectedFileSize
+	binaryenConfig.expectedSha256 = expectedSha256
+	binaryenConfig.toolchainDir = toolchainDir
+	binaryenConfig.toolchainVersion = toolchainVersion
+	binaryenConfig.toolchainExecutable = toolchainExecutable
+	binaryenConfig.version = version
+	binaryenConfig.versionedDir = versionedDir
+	return binaryenConfig, nil
+}
+
+func transformBinaryenTarGz(destinationDir string, versionedDir string, filePath string) string {
+	// Strip the versioned directory prefix (e.g., "binaryen-version_125/")
+	prefix := versionedDir + "/"
+	return filepath.Join(destinationDir, strings.TrimPrefix(filePath, prefix))
+}
+
+func transformBinaryenTarGzFactory(destinationDir string, versionedDir string) fileTransformer {
+	destinationDir = ensureTrailingSlash(destinationDir)
+	return func(filePath string) string {
+		return transformBinaryenTarGz(destinationDir, versionedDir, filePath)
+	}
+}
+
+func updateBinaryenToolchainToml(toolchainDir string, executable string, version string) error {
+	toolchainTomlTopLevel, err := ReadToolchainToml(toolchainDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		toolchainTomlTopLevel = new(ToolchainTomlTopLevel)
+	}
+	if toolchainTomlTopLevel.Binaryen == nil {
+		toolchainTomlTopLevel.Binaryen = new(ToolchainTomlTool)
+	}
+	toolchainTomlTopLevel.Binaryen.Executable = executable
+	toolchainTomlTopLevel.Binaryen.Version = version
+	return WriteToolchainToml(toolchainDir, toolchainTomlTopLevel)
+}

--- a/internal/build-tool/config.go
+++ b/internal/build-tool/config.go
@@ -52,6 +52,7 @@ type ConfigTomlBuildTool struct {
 	DownloadsFile        string
 	ToolChainDirTemplate string
 
+	Binaryen  ConfigTomlTool     `toml:"binaryen"`
 	Bison     ConfigTomlTool     `toml:"bison"`
 	BpfAsm    ConfigTomlBpfAsm   `toml:"bpf_asm"`
 	CapnProto ConfigTomlTool     `toml:"capnproto"`
@@ -120,6 +121,7 @@ type RuntimeConfigBuildTool struct {
 	Directories *runtimeConfigDirectories
 	Executables *runtimeConfigExecutables
 
+	Binaryen  *runtimeConfigTool
 	Bison     *runtimeConfigTool
 	BpfAsm    *runtimeConfigBpfAsm
 	CapnProto *runtimeConfigTool
@@ -254,6 +256,14 @@ func BuildConfiguration(configFile *ConfigTomlTopLevel, downloadsFile *Downloads
 	}
 	config.Executables = new(runtimeConfigExecutables)
 	err = populateExecutablesRuntimeConfig(config, configFile, toolchainToml)
+	if err != nil {
+		return nil, err
+	}
+	// Binaryen
+	config.Binaryen = new(runtimeConfigTool)
+	config.Binaryen.Name = "Binaryen"
+	config.Binaryen.Prefix = "binaryen-version_"
+	err = populateToolRuntimeConfig(config.Binaryen, config.Directories, &configFile.BuildTool.Binaryen, &downloadsFile.Binaryen, toolchainToml.Binaryen)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/build-tool/downloads.go
+++ b/internal/build-tool/downloads.go
@@ -21,6 +21,7 @@ import (
 )
 
 type DownloadsTomlTopLevel struct {
+	Binaryen  DownloadsTomlTool `toml:"binaryen"`
 	Bison     DownloadsTomlTool `toml:"bison"`
 	CapnProto DownloadsTomlTool `toml:"capnproto"`
 	Flex      DownloadsTomlTool `toml:"flex"`

--- a/internal/build-tool/downloads.toml
+++ b/internal/build-tool/downloads.toml
@@ -1,3 +1,20 @@
+[binaryen]
+DownloadUrlTemplate = "https://github.com/WebAssembly/binaryen/releases/download/version_{{ .Version }}/{{ .Filename }}"
+FilenameTemplate = "binaryen-version_{{ .Version }}-{{ .Arch }}-{{ .OS }}.tar.gz"
+PreferredVersion = "125"
+
+[binaryen.files."binaryen-version_125-arm64-macos.tar.gz"]
+SHA-256 = "28bab047c4ce845c5c1da111222ffee5fafcec0bbedd046ad8b3dcae0fd57076"
+Size = 6827261
+
+[binaryen.files."binaryen-version_125-aarch64-linux.tar.gz"]
+SHA-256 = "d0382de3c189a7cbb9fdda93e2966f4557f6a00f201e2c4937c27ca01cead4fc"
+Size = 103059268
+
+[binaryen.files."binaryen-version_125-x86_64-linux.tar.gz"]
+SHA-256 = "7c3bc16599c8274a04d34a504fe4be2047884f900e0e2da2f6fb9cd667183be4"
+Size = 106809634
+
 [bison]
 DownloadUrlTemplate = "https://ftpmirror.gnu.org/bison/{{ .Filename }}"
 FilenameTemplate = "bison-{{ .Version }}.tar.xz"

--- a/internal/build-tool/downloads.toml
+++ b/internal/build-tool/downloads.toml
@@ -1,6 +1,6 @@
 [binaryen]
 DownloadUrlTemplate = "https://github.com/WebAssembly/binaryen/releases/download/version_{{ .Version }}/{{ .Filename }}"
-FilenameTemplate = "binaryen-version_{{ .Version }}-{{ .Arch }}-{{ .OS }}.tar.gz"
+FilenameTemplate = "binaryen-version_{{ .Version }}-{{ .Arch }}-{{ .Os }}.tar.gz"
 PreferredVersion = "125"
 
 [binaryen.files."binaryen-version_125-arm64-macos.tar.gz"]

--- a/internal/build-tool/toolchain.go
+++ b/internal/build-tool/toolchain.go
@@ -24,6 +24,7 @@ import (
 )
 
 type ToolchainTomlTopLevel struct {
+	Binaryen  *ToolchainTomlTool `toml:"binaryen"`
 	Bison     *ToolchainTomlTool `toml:"bison"`
 	BpfAsm    *ToolchainTomlTool `toml:"bpf-asm"`
 	CapnProto *ToolchainTomlTool `toml:"capnproto"`


### PR DESCRIPTION
1. We pull `tinygo` into the toolchain, but our build only looks for it system-wide
2. When I tried to build the frontend with tinygo it said I needed binaryen/wasm-opt, so I added binaryen to the toolchain and configured it via env variable in the build.

The difference is substantial, ~5MB -> 580KB for the client wasm file.